### PR TITLE
Various changes

### DIFF
--- a/timeliney.typ
+++ b/timeliney.typ
@@ -14,10 +14,10 @@
   offset: 0,
 ) = layout(
       size => {
-        canvas(
+        canvas.with(
           debug: false,
           length: size.width,
-          {
+        )({
             import draw: *
 
             let headers = ()
@@ -41,8 +41,7 @@
             }
 
             // Task titles
-            group(
-              {
+            group.with(name: "titles")({
                 let i = 0
                 for task in tasks {
                   if task.type == "task" {
@@ -124,16 +123,11 @@
                     )
                   }
                 }
-              },
-              name: "titles",
-            )
+              })
 
             // Now that we have laid out the task titles, we can render the task group boxes
-            group(
-              ctx => {
-                on-layer(
-                  1,
-                  {
+            group.with(name: "boxes")(
+              ctx => on-layer.with(1)({
                     let start_x = coordinate.resolve(ctx, "titles.north-west").at(1).at(0)
                     let end_x = 1 + start_x
 
@@ -182,10 +176,7 @@
 
                       rect(start, end, stroke: 1pt)
                     }
-                  },
-                )
-              },
-              name: "boxes",
+                  }),
             )
 
             get-ctx(
@@ -194,7 +185,7 @@
                 let end_x = 1 + coordinate.resolve(ctx, "titles.north-west").at(1).at(0)
                 let end_y = coordinate.resolve(ctx, "titles.south").at(1).at(1)
 
-                group(
+                group.with(name: "top-headers")(
                   {
                     for (i, header) in headers.rev().enumerate() {
                       let passed = 0
@@ -232,7 +223,6 @@
                       }
                     }
                   },
-                  name: "top-headers",
                 )
 
                 // Draw the lines
@@ -266,9 +256,7 @@
                 if show-grid != false {
                   let month_width = (end_x - start_x) / n_cols
 
-                  on-layer(
-                    -1,
-                    {
+                  on-layer.with(-1)({
                       // Horizontal
                       if show-grid == true or show-grid == "x" {
                         for i in range(1, n_cols) {
@@ -296,8 +284,7 @@
 
                       // Border all around the timeline
                       rect("titles.north-west", (end_x, end_y), stroke: black + 1pt)
-                    },
-                  )
+                    })
                 }
 
                 // Milestones
@@ -335,12 +322,9 @@
                           }
 
                           line((x, start_y), (rel: (0, overhang.pt() * pt), to: pos), ..style)
-                          on-layer(
-                            1,
-                            {
+                          on-layer.with(1)({
                               content((box_x, pos.y), anchor: anchor, body, name: "milestone" + str(i))
-                            },
-                          )
+                            })
                         },
                       )
                     } else if milestone-layout == "aligned" {
@@ -350,7 +334,7 @@
                     }
                   }
 
-                  on-layer(-0.5, {
+                  on-layer.with(-0.5)({
                     if milestone-layout == "aligned" {
                       set-ctx(ctx => {
                         ctx.prev.pt = coordinate.resolve(ctx, "titles.south").at(1)

--- a/timeliney.typ
+++ b/timeliney.typ
@@ -1,4 +1,4 @@
-#import "@preview/cetz:0.2.2": canvas, draw, coordinate, util
+#import "@preview/cetz:0.3.1": canvas, draw, coordinate, util
 
 #let timeline(
   body,

--- a/timeliney.typ
+++ b/timeliney.typ
@@ -12,9 +12,7 @@
   box-milestones: true,
   milestone-line-style: (),
   offset: 0,
-) = style(
-  styles => {
-    layout(
+) = layout(
       size => {
         canvas(
           debug: false,
@@ -370,8 +368,6 @@
         )
       },
     )
-  },
-)
 
 #let headerline(..args) = {
   let groups = args.pos()

--- a/timeliney.typ
+++ b/timeliney.typ
@@ -12,12 +12,7 @@
   box-milestones: true,
   milestone-line-style: (),
   offset: 0,
-) = layout(
-      size => {
-        canvas.with(
-          debug: false,
-          length: size.width,
-        )({
+) = layout(size => canvas.with(debug: false, length: size.width)({
             import draw: *
 
             let headers = ()
@@ -126,8 +121,7 @@
               })
 
             // Now that we have laid out the task titles, we can render the task group boxes
-            group.with(name: "boxes")(
-              ctx => on-layer.with(1)({
+            group.with(name: "boxes")(ctx => on-layer.with(1)({
                     let start_x = coordinate.resolve(ctx, "titles.north-west").at(1).at(0)
                     let end_x = 1 + start_x
 
@@ -176,17 +170,14 @@
 
                       rect(start, end, stroke: 1pt)
                     }
-                  }),
-            )
+                  }))
 
-            get-ctx(
-              ctx => {
+            get-ctx(ctx => {
                 let (start_x, start_y, _) = coordinate.resolve(ctx, "titles.north-east").at(1)
                 let end_x = 1 + coordinate.resolve(ctx, "titles.north-west").at(1).at(0)
                 let end_y = coordinate.resolve(ctx, "titles.south").at(1).at(1)
 
-                group.with(name: "top-headers")(
-                  {
+                group.with(name: "top-headers")({
                     for (i, header) in headers.rev().enumerate() {
                       let passed = 0
                       for group in header {
@@ -222,8 +213,7 @@
                         rect(group_start, group_end, ..group_style)
                       }
                     }
-                  },
-                )
+                  })
 
                 // Draw the lines
                 for (i, task) in flat_tasks.enumerate() {
@@ -302,8 +292,7 @@
                     if milestone-layout == "in-place" {
                       let x = (end_x - start_x) * ((at + offset) / n_cols) + start_x
 
-                      get-ctx(
-                        ctx => {
+                      get-ctx(ctx => {
                           let pos = (x: x, y: end_y - (spacing + overhang).pt() * pt)
                           let box_x = x
 
@@ -325,8 +314,7 @@
                           on-layer.with(1)({
                               content((box_x, pos.y), anchor: anchor, body, name: "milestone" + str(i))
                             })
-                        },
-                      )
+                        })
                     } else if milestone-layout == "aligned" {
                       let x = (end_x - start_x) * (at / n_cols) + start_x
                       let end_y = coordinate.resolve(ctx, "titles.milestone" + str(i) + "-right").at(1).at(1)
@@ -346,12 +334,8 @@
                     }
                   })
                 }
-              },
-            )
-          },
-        )
-      },
-    )
+              })
+          }))
 
 #let headerline(..args) = {
   let groups = args.pos()

--- a/timeliney.typ
+++ b/timeliney.typ
@@ -13,329 +13,329 @@
   milestone-line-style: (),
   offset: 0,
 ) = layout(size => canvas.with(debug: false, length: size.width)({
-            import draw: *
+  import draw: *
 
-            let headers = ()
-            let tasks = ()
-            let flat_tasks = ()
-            let milestones = ()
-            let n_cols = 0
-            let pt = 1 / size.width.pt()
+  let headers = ()
+  let tasks = ()
+  let flat_tasks = ()
+  let milestones = ()
+  let n_cols = 0
+  let pt = 1 / size.width.pt()
 
-            for line in body {
-              if line.type == "header" {
-                headers.push(line.headers)
-                if line.total > n_cols {
-                  n_cols = line.total
-                }
-              } else if line.type == "task" or line.type == "taskgroup" {
-                tasks.push(line)
-              } else if line.type == "milestone" {
-                milestones.push(line)
+  for line in body {
+    if line.type == "header" {
+      headers.push(line.headers)
+      if line.total > n_cols {
+        n_cols = line.total
+      }
+    } else if line.type == "task" or line.type == "taskgroup" {
+      tasks.push(line)
+    } else if line.type == "milestone" {
+      milestones.push(line)
+    }
+  }
+
+  // Task titles
+  group.with(name: "titles")({
+    let i = 0
+    for task in tasks {
+      if task.type == "task" {
+        content(
+          (rel: (0, 0)),
+          task.name,
+          anchor: "north",
+          name: "task" + str(i),
+          padding: spacing,
+        )
+
+        anchor(
+          "task" + str(i) + "-bottom",
+          (rel: (0, 0), to: "task" + str(i) + ".south", update: true),
+        )
+        anchor(
+          "task" + str(i) + "-top",
+          (rel: (0, 0), to: "task" + str(i) + ".north-west", update: false),
+        )
+        anchor(
+          "task" + str(i),
+          (rel: (0, 0), to: "task" + str(i) + ".east", update: false),
+        )
+
+        flat_tasks.push(task)
+
+        i += 1
+      } else if task.type == "taskgroup" {
+        for t in task.tasks {
+          content(
+            (rel: (0, 0)),
+            t.name,
+            anchor: "north",
+            name: "task" + str(i),
+            padding: spacing,
+          )
+
+          anchor(
+            "task" + str(i) + "-bottom",
+            (rel: (0, 0), to: "task" + str(i) + ".south", update: true),
+          )
+          anchor(
+            "task" + str(i) + "-top",
+            (rel: (0, 0), to: "task" + str(i) + ".north-west", update: false),
+          )
+          anchor(
+            "task" + str(i),
+            (rel: (0, 0), to: "task" + str(i) + ".east", update: false),
+          )
+
+          flat_tasks.push(t)
+
+          i += 1
+        }
+      }
+    }
+
+    if milestone-layout == "aligned" {
+      for (i, milestone) in milestones.enumerate() {
+        content(
+          (rel: (0, 0)),
+          milestone.body,
+          anchor: "north",
+          name: "milestone" + str(i),
+          padding: spacing,
+        )
+
+        anchor(
+          "milestone" + str(i) + "-bottom",
+          (rel: (0, 0), to: "milestone" + str(i) + ".south", update: true),
+        )
+        anchor(
+          "milestone" + str(i) + "-right",
+          (rel: (0, 0), to: "milestone" + str(i) + ".east", update: false),
+        )
+        anchor(
+          "milestone" + str(i) + "-top",
+          (rel: (0, 0), to: "milestone" + str(i) + ".north", update: false),
+        )
+      }
+    }
+  })
+
+  // Now that we have laid out the task titles, we can render the task group boxes
+  group.with(name: "boxes")(ctx => on-layer.with(1)({
+    let start_x = coordinate.resolve(ctx, "titles.north-west").at(1).at(0)
+    let end_x = 1 + start_x
+
+    let i = 0
+    for group in tasks {
+      if group.type != "taskgroup" {
+        i += 1
+        continue
+      }
+
+      let start_i = i
+      let group_start = none
+      let group_end = none
+
+      for task in group.tasks {
+        if group_start == none {
+          let start_y = coordinate.resolve(ctx, "titles.task" + str(i) + "-top").at(1).at(1)
+          group_start = (start_x, start_y)
+        }
+
+        let end_y = coordinate.resolve(ctx, "titles.task" + str(i) + "-bottom").at(1).at(1)
+        group_end = (end_x, end_y)
+
+        i += 1
+      }
+
+      rect(group_start, group_end, stroke: 1pt)
+    }
+
+    if tasks-vline {
+      line("titles.north-east", "titles.south-east")
+    }
+
+    if box-milestones and milestone-layout == "aligned" {
+      let start = none
+      let end = none
+
+      for (i, milestone) in milestones.enumerate() {
+        if start == none {
+          let start_y = coordinate.resolve(ctx, "titles.milestone" + str(i) + "-top").at(1).at(1)
+          start = (start_x, start_y)
+        }
+        let end_y = coordinate.resolve(ctx, "titles.milestone" + str(i) + "-bottom").at(1).at(1)
+        end = (end_x, end_y)
+      }
+
+      rect(start, end, stroke: 1pt)
+    }
+  }))
+
+  get-ctx(ctx => {
+    let (start_x, start_y, _) = coordinate.resolve(ctx, "titles.north-east").at(1)
+    let end_x = 1 + coordinate.resolve(ctx, "titles.north-west").at(1).at(0)
+    let end_y = coordinate.resolve(ctx, "titles.south").at(1).at(1)
+
+    group.with(name: "top-headers")({
+      for (i, header) in headers.rev().enumerate() {
+        let passed = 0
+        for group in header {
+          let group_start = none
+          let group_end = none
+
+          for (name, len) in group.titles {
+            let start = (
+              a: (start_x, start_y + 16 * (i + 1) * pt),
+              b: (end_x, start_y + 16 * (i + 1) * pt),
+              number: passed / n_cols * 100%,
+            )
+
+            if group_start == none { group_start = start }
+
+            let end = (
+              a: (start_x, start_y + 16 * i * pt),
+              b: (end_x, start_y + 16 * i * pt),
+              number: (passed + len) / n_cols * 100%,
+            )
+
+            group_end = end
+
+            content(start, end, anchor: "north-west", align(center + horizon, name))
+
+            passed += len
+          }
+
+          let group_style = (stroke: 1pt + black)
+          if "style" in group {
+            group_style = group.style
+          }
+          rect(group_start, group_end, ..group_style)
+        }
+      }
+    })
+
+    // Draw the lines
+    for (i, task) in flat_tasks.enumerate() {
+      let start = "titles.task" + str(i)
+      let task_start_y = coordinate.resolve(ctx, "titles.task" + str(i)).at(1).at(1)
+      let (task_top_x, task_top_y, _) = coordinate.resolve(ctx, "titles.task" + str(i) + "-top").at(1)
+      let task_bottom_y = coordinate.resolve(ctx, "titles.task" + str(i) + "-bottom").at(1).at(1)
+      let h = task_top_y - task_bottom_y
+
+      for gantt_line in task.lines {
+        let start = (
+          a: (start_x, task_start_y),
+          b: (end_x, task_start_y),
+          number: (gantt_line.from + offset) / n_cols * 100%,
+        )
+
+        let end = (
+          a: (start_x, task_start_y),
+          b: (end_x, task_start_y),
+          number: (gantt_line.to + offset) / n_cols * 100%,
+        )
+
+        let style = line-style
+        if ("style" in gantt_line) { style = gantt_line.style }
+        line(start, end, ..style)
+      }
+    }
+
+    // Grid
+    if show-grid != false {
+      let month_width = (end_x - start_x) / n_cols
+
+      on-layer.with(-1)({
+        // Horizontal
+        if show-grid == true or show-grid == "x" {
+          for i in range(1, n_cols) {
+            line(
+              (start_x + month_width * i, start_y),
+              (start_x + month_width * i, end_y),
+              ..grid-style,
+            )
+          }
+        }
+
+        if show-grid == true or show-grid == "y" {
+          for (i, task) in flat_tasks.enumerate() {
+            let task_bottom_y = coordinate.resolve(ctx, "titles.task" + str(i) + "-bottom").at(1).at(1)
+            line((start_x, task_bottom_y), (end_x, task_bottom_y), ..grid-style)
+          }
+
+          if milestone-layout == "aligned" {
+            for (i, milestone) in milestones.enumerate() {
+              let bottom_y = coordinate.resolve(ctx, "titles.milestone" + str(i) + "-bottom").at(1).at(1)
+              line((start_x, bottom_y), (end_x, bottom_y), ..grid-style)
+            }
+          }
+        }
+
+        // Border all around the timeline
+        rect("titles.north-west", (end_x, end_y), stroke: black + 1pt)
+      })
+    }
+
+    // Milestones
+    if milestones.len() > 0 {
+      let draw-milestone(
+        i,
+        at: 0,
+        body: "",
+        style: milestone-line-style,
+        overhang: milestone-overhang,
+        spacing: spacing,
+        anchor: "north",
+        type: "milestone",
+      ) = {
+        if milestone-layout == "in-place" {
+          let x = (end_x - start_x) * ((at + offset) / n_cols) + start_x
+
+          get-ctx(ctx => {
+            let pos = (x: x, y: end_y - (spacing + overhang).pt() * pt)
+            let box_x = x
+
+            let (w, h) = util.measure(ctx, body)
+            if x + w / 2 > end_x {
+              box_x = end_x - w / 2
+            }
+
+            if i != 0 {
+              let (prev_end_x, prev_start_y, _) = coordinate.resolve-anchor(ctx, "milestone" + str(i - 1) + ".north-east")
+              let prev_end_y = coordinate.resolve-anchor(ctx, "milestone" + str(i - 1) + ".south").at(1)
+
+              if box_x - w / 2 < prev_end_x and pos.y <= prev_start_y and pos.y + h >= prev_end_y {
+                pos = (x: x, y: prev_end_y - spacing.pt() * pt * 2)
               }
             }
 
-            // Task titles
-            group.with(name: "titles")({
-                let i = 0
-                for task in tasks {
-                  if task.type == "task" {
-                    content(
-                      (rel: (0, 0)),
-                      task.name,
-                      anchor: "north",
-                      name: "task" + str(i),
-                      padding: spacing,
-                    )
+            line((x, start_y), (rel: (0, overhang.pt() * pt), to: pos), ..style)
+            on-layer.with(1)({
+              content((box_x, pos.y), anchor: anchor, body, name: "milestone" + str(i))
+            })
+          })
+        } else if milestone-layout == "aligned" {
+          let x = (end_x - start_x) * (at / n_cols) + start_x
+          let end_y = coordinate.resolve(ctx, "titles.milestone" + str(i) + "-right").at(1).at(1)
+          line((x, start_y), (x, end_y), (start_x, end_y), ..style)
+        }
+      }
 
-                    anchor(
-                      "task" + str(i) + "-bottom",
-                      (rel: (0, 0), to: "task" + str(i) + ".south", update: true),
-                    )
-                    anchor(
-                      "task" + str(i) + "-top",
-                      (rel: (0, 0), to: "task" + str(i) + ".north-west", update: false),
-                    )
-                    anchor(
-                      "task" + str(i),
-                      (rel: (0, 0), to: "task" + str(i) + ".east", update: false),
-                    )
-
-                    flat_tasks.push(task)
-
-                    i += 1
-                  } else if task.type == "taskgroup" {
-                    for t in task.tasks {
-                      content(
-                        (rel: (0, 0)),
-                        t.name,
-                        anchor: "north",
-                        name: "task" + str(i),
-                        padding: spacing,
-                      )
-
-                      anchor(
-                        "task" + str(i) + "-bottom",
-                        (rel: (0, 0), to: "task" + str(i) + ".south", update: true),
-                      )
-                      anchor(
-                        "task" + str(i) + "-top",
-                        (rel: (0, 0), to: "task" + str(i) + ".north-west", update: false),
-                      )
-                      anchor(
-                        "task" + str(i),
-                        (rel: (0, 0), to: "task" + str(i) + ".east", update: false),
-                      )
-
-                      flat_tasks.push(t)
-
-                      i += 1
-                    }
-                  }
-                }
-
-                if milestone-layout == "aligned" {
-                  for (i, milestone) in milestones.enumerate() {
-                    content(
-                      (rel: (0, 0)),
-                      milestone.body,
-                      anchor: "north",
-                      name: "milestone" + str(i),
-                      padding: spacing,
-                    )
-
-                    anchor(
-                      "milestone" + str(i) + "-bottom",
-                      (rel: (0, 0), to: "milestone" + str(i) + ".south", update: true),
-                    )
-                    anchor(
-                      "milestone" + str(i) + "-right",
-                      (rel: (0, 0), to: "milestone" + str(i) + ".east", update: false),
-                    )
-                    anchor(
-                      "milestone" + str(i) + "-top",
-                      (rel: (0, 0), to: "milestone" + str(i) + ".north", update: false),
-                    )
-                  }
-                }
-              })
-
-            // Now that we have laid out the task titles, we can render the task group boxes
-            group.with(name: "boxes")(ctx => on-layer.with(1)({
-                    let start_x = coordinate.resolve(ctx, "titles.north-west").at(1).at(0)
-                    let end_x = 1 + start_x
-
-                    let i = 0
-                    for group in tasks {
-                      if group.type != "taskgroup" {
-                        i += 1
-                        continue
-                      }
-
-                      let start_i = i
-                      let group_start = none
-                      let group_end = none
-
-                      for task in group.tasks {
-                        if group_start == none {
-                          let start_y = coordinate.resolve(ctx, "titles.task" + str(i) + "-top").at(1).at(1)
-                          group_start = (start_x, start_y)
-                        }
-
-                        let end_y = coordinate.resolve(ctx, "titles.task" + str(i) + "-bottom").at(1).at(1)
-                        group_end = (end_x, end_y)
-
-                        i += 1
-                      }
-
-                      rect(group_start, group_end, stroke: 1pt)
-                    }
-
-                    if tasks-vline {
-                      line("titles.north-east", "titles.south-east")
-                    }
-
-                    if box-milestones and milestone-layout == "aligned" {
-                      let start = none
-                      let end = none
-
-                      for (i, milestone) in milestones.enumerate() {
-                        if start == none {
-                          let start_y = coordinate.resolve(ctx, "titles.milestone" + str(i) + "-top").at(1).at(1)
-                          start = (start_x, start_y)
-                        }
-                        let end_y = coordinate.resolve(ctx, "titles.milestone" + str(i) + "-bottom").at(1).at(1)
-                        end = (end_x, end_y)
-                      }
-
-                      rect(start, end, stroke: 1pt)
-                    }
-                  }))
-
-            get-ctx(ctx => {
-                let (start_x, start_y, _) = coordinate.resolve(ctx, "titles.north-east").at(1)
-                let end_x = 1 + coordinate.resolve(ctx, "titles.north-west").at(1).at(0)
-                let end_y = coordinate.resolve(ctx, "titles.south").at(1).at(1)
-
-                group.with(name: "top-headers")({
-                    for (i, header) in headers.rev().enumerate() {
-                      let passed = 0
-                      for group in header {
-                        let group_start = none
-                        let group_end = none
-
-                        for (name, len) in group.titles {
-                          let start = (
-                            a: (start_x, start_y + 16 * (i + 1) * pt),
-                            b: (end_x, start_y + 16 * (i + 1) * pt),
-                            number: passed / n_cols * 100%,
-                          )
-
-                          if group_start == none { group_start = start }
-
-                          let end = (
-                            a: (start_x, start_y + 16 * i * pt),
-                            b: (end_x, start_y + 16 * i * pt),
-                            number: (passed + len) / n_cols * 100%,
-                          )
-
-                          group_end = end
-
-                          content(start, end, anchor: "north-west", align(center + horizon, name))
-
-                          passed += len
-                        }
-
-                        let group_style = (stroke: 1pt + black)
-                        if "style" in group {
-                          group_style = group.style
-                        }
-                        rect(group_start, group_end, ..group_style)
-                      }
-                    }
-                  })
-
-                // Draw the lines
-                for (i, task) in flat_tasks.enumerate() {
-                  let start = "titles.task" + str(i)
-                  let task_start_y = coordinate.resolve(ctx, "titles.task" + str(i)).at(1).at(1)
-                  let (task_top_x, task_top_y, _) = coordinate.resolve(ctx, "titles.task" + str(i) + "-top").at(1)
-                  let task_bottom_y = coordinate.resolve(ctx, "titles.task" + str(i) + "-bottom").at(1).at(1)
-                  let h = task_top_y - task_bottom_y
-
-                  for gantt_line in task.lines {
-                    let start = (
-                      a: (start_x, task_start_y),
-                      b: (end_x, task_start_y),
-                      number: (gantt_line.from + offset) / n_cols * 100%,
-                    )
-
-                    let end = (
-                      a: (start_x, task_start_y),
-                      b: (end_x, task_start_y),
-                      number: (gantt_line.to + offset) / n_cols * 100%,
-                    )
-
-                    let style = line-style
-                    if ("style" in gantt_line) { style = gantt_line.style }
-                    line(start, end, ..style)
-                  }
-                }
-
-                // Grid
-                if show-grid != false {
-                  let month_width = (end_x - start_x) / n_cols
-
-                  on-layer.with(-1)({
-                      // Horizontal
-                      if show-grid == true or show-grid == "x" {
-                        for i in range(1, n_cols) {
-                          line(
-                            (start_x + month_width * i, start_y),
-                            (start_x + month_width * i, end_y),
-                            ..grid-style,
-                          )
-                        }
-                      }
-
-                      if show-grid == true or show-grid == "y" {
-                        for (i, task) in flat_tasks.enumerate() {
-                          let task_bottom_y = coordinate.resolve(ctx, "titles.task" + str(i) + "-bottom").at(1).at(1)
-                          line((start_x, task_bottom_y), (end_x, task_bottom_y), ..grid-style)
-                        }
-
-                        if milestone-layout == "aligned" {
-                          for (i, milestone) in milestones.enumerate() {
-                            let bottom_y = coordinate.resolve(ctx, "titles.milestone" + str(i) + "-bottom").at(1).at(1)
-                            line((start_x, bottom_y), (end_x, bottom_y), ..grid-style)
-                          }
-                        }
-                      }
-
-                      // Border all around the timeline
-                      rect("titles.north-west", (end_x, end_y), stroke: black + 1pt)
-                    })
-                }
-
-                // Milestones
-                if milestones.len() > 0 {
-                  let draw-milestone(
-                    i,
-                    at: 0,
-                    body: "",
-                    style: milestone-line-style,
-                    overhang: milestone-overhang,
-                    spacing: spacing,
-                    anchor: "north",
-                    type: "milestone",
-                  ) = {
-                    if milestone-layout == "in-place" {
-                      let x = (end_x - start_x) * ((at + offset) / n_cols) + start_x
-
-                      get-ctx(ctx => {
-                          let pos = (x: x, y: end_y - (spacing + overhang).pt() * pt)
-                          let box_x = x
-
-                          let (w, h) = util.measure(ctx, body)
-                          if x + w / 2 > end_x {
-                            box_x = end_x - w / 2
-                          }
-
-                          if i != 0 {
-                            let (prev_end_x, prev_start_y, _) = coordinate.resolve-anchor(ctx, "milestone" + str(i - 1) + ".north-east")
-                            let prev_end_y = coordinate.resolve-anchor(ctx, "milestone" + str(i - 1) + ".south").at(1)
-
-                            if box_x - w / 2 < prev_end_x and pos.y <= prev_start_y and pos.y + h >= prev_end_y {
-                              pos = (x: x, y: prev_end_y - spacing.pt() * pt * 2)
-                            }
-                          }
-
-                          line((x, start_y), (rel: (0, overhang.pt() * pt), to: pos), ..style)
-                          on-layer.with(1)({
-                              content((box_x, pos.y), anchor: anchor, body, name: "milestone" + str(i))
-                            })
-                        })
-                    } else if milestone-layout == "aligned" {
-                      let x = (end_x - start_x) * (at / n_cols) + start_x
-                      let end_y = coordinate.resolve(ctx, "titles.milestone" + str(i) + "-right").at(1).at(1)
-                      line((x, start_y), (x, end_y), (start_x, end_y), ..style)
-                    }
-                  }
-
-                  on-layer.with(-0.5)({
-                    if milestone-layout == "aligned" {
-                      set-ctx(ctx => {
-                        ctx.prev.pt = coordinate.resolve(ctx, "titles.south").at(1)
-                        return ctx
-                      })
-                    }
-                    for (i, milestone) in milestones.enumerate() {
-                      draw-milestone(i, ..milestone)
-                    }
-                  })
-                }
-              })
-          }))
+      on-layer.with(-0.5)({
+        if milestone-layout == "aligned" {
+          set-ctx(ctx => {
+            ctx.prev.pt = coordinate.resolve(ctx, "titles.south").at(1)
+            return ctx
+          })
+        }
+        for (i, milestone) in milestones.enumerate() {
+          draw-milestone(i, ..milestone)
+        }
+      })
+    }
+  })
+}))
 
 #let headerline(..args) = {
   let groups = args.pos()


### PR DESCRIPTION
- update CeTZ to 0.3.1
- fix #7
- reformat code to reduce indentation

I tried my best to keep the changes easy to review by splitting them into multiple commits.

I put off re-indenting the code until the last commit, so that
- commits containing semantic or structural changes do not contain unrelated formatting changes
- formatting changes can be verified not to contain structural change by inspecting with `--ignore--all-space` on the commandline or GitHub's `Hide whitespace` option

Sorry bundling all this into one PR.