### PR TITLE
fix: the height of header can adapt the line sizes based off the size of the text and argument "header-spacing"

### DIFF
--- a/timeliney.typ
+++ b/timeliney.typ
@@ -3,6 +3,7 @@
 #let timeline(
   body,
   spacing: 5pt,
+  heading-spacing: 10pt,
   show-grid: false,
   grid-style: (stroke: (dash: "dashed", thickness: .5pt, paint: gray)),
   tasks-vline: true,
@@ -21,6 +22,8 @@
   let milestones = ()
   let n_cols = 0
   let pt = 1 / size.width.pt()
+
+  let heading-spacing = heading-spacing.pt()
 
   for line in body {
     if line.type == "header" {
@@ -178,7 +181,24 @@
     let end_y = coordinate.resolve(ctx, "titles.south").at(1).at(1)
 
     group.with(name: "top-headers")({
+
+      // the offset to the start_y, use unit pt
+      let current_start_y_offset = 0
+
       for (i, header) in headers.rev().enumerate() {
+        
+        // before creat content, find the hightest name, and the height of header will fit it
+        let max_name_height = 0
+        for group in header {
+          for (name, len) in group.titles {
+            let name_height = measure(name).height.pt()
+            if max_name_height < name_height {
+              max_name_height = name_height
+            }
+          }
+        }
+        let current_header_height = max_name_height + heading-spacing
+
         let passed = 0
         for group in header {
           let group_start = none
@@ -186,16 +206,16 @@
 
           for (name, len) in group.titles {
             let start = (
-              a: (start_x, start_y + 16 * (i + 1) * pt),
-              b: (end_x, start_y + 16 * (i + 1) * pt),
+              a: (start_x, start_y + (current_start_y_offset + current_header_height) * pt),
+              b: (end_x, start_y + (current_start_y_offset + current_header_height) * pt),
               number: passed / n_cols * 100%,
             )
 
             if group_start == none { group_start = start }
 
             let end = (
-              a: (start_x, start_y + 16 * i * pt),
-              b: (end_x, start_y + 16 * i * pt),
+              a: (start_x, start_y + current_start_y_offset * pt),
+              b: (end_x, start_y + current_start_y_offset * pt),
               number: (passed + len) / n_cols * 100%,
             )
 
@@ -212,6 +232,9 @@
           }
           rect(group_start, group_end, ..group_style)
         }
+
+          // add current height to offset, get the offset of next line of header
+          current_start_y_offset = current_start_y_offset + current_header_height
       }
     })
 


### PR DESCRIPTION
Fix the bug https://github.com/pta2002/typst-timeliney/issues/10#issue-2780016468 by automatically adapt the line sizes based off the size of the text.

The height of header now can adapt the line sizes based off the size of the text and argument "header-spacing". To get this, I use a variable call `max_name_height` to find the hightest name and the height of header will fit it (equal to `max_name_height` add `header-spacing`) before create content.

For example:
code:
```typst
#timeliney.timeline(
  show-grid: true,
  heading-spacing: 20pt,
  {
    import timeliney: *
      
    headerline(group(([#text(size: 50pt)[*2023*]], 4)), group(([*2024*], 4)))
    headerline(
      group(..range(4).map(n => strong("Q" + str(n + 1)))),
      group(..range(4).map(n => text(size: 20pt, "Q" + str(n + 1)))),
    )

    ....
```

result:
![effect](https://github.com/user-attachments/assets/36a86720-8fb5-4da3-bf37-a8d95dc07c92)
