### PR TITLE
Update cetz to 0.3.2

### DIFF
--- a/timeliney.typ
+++ b/timeliney.typ
@@ -1,4 +1,4 @@
-#import "@preview/cetz:0.3.1": canvas, draw, coordinate, util
+#import "@preview/cetz:0.3.2": canvas, draw, coordinate, util
 
 #let timeline(
   body,


### PR DESCRIPTION
This PR updates cetz to the latest version. I was experiencing some compatibility issues while using Typst 0.13.0 that _might_ actually be fixed by updating the dependency.