### PR TITLE
Update cetz version to 0.4.1

### DIFF
--- a/timeliney.typ
+++ b/timeliney.typ
@@ -1,4 +1,4 @@
-#import "@preview/cetz:0.3.2": canvas, draw, coordinate, util
+#import "@preview/cetz:0.4.1": canvas, draw, coordinate, util
 
 #let timeline(
   body,


### PR DESCRIPTION
Update cetz version.
This update should not break anything:
**With `cetz 0.3.2`:**
![old](https://github.com/user-attachments/assets/7e0b00b0-2694-4c97-9e32-bab778b678a3)
**With `cetz 0.4.1`:**
![new](https://github.com/user-attachments/assets/b42e59fa-a6aa-4080-80ca-ae4362910914)


This PR closes #19.

