### PR TITLE
[fix] sort the milestones for correct layout

### DIFF
--- a/timeliney.typ
+++ b/timeliney.typ
@@ -40,6 +40,9 @@
     }
   }
 
+  // sort the milestones for correct layout
+  milestones = milestones.sorted(key: m => m.at)
+
   // Task titles
   group.with(name: "titles")({
     let i = 0


### PR DESCRIPTION
When `milestone-layount == "in-place"`, the rendering code assumes that milestones are chronologically sorted to decide which to put lower than the others to avoid collisions. This creates rendering bugs when users group their milestone by tasks and do not write them in time order, see #18.

The present PR sorts all milestones by `at` field before doing any rendering.

This is clearly a bugfix for the `"in-place"` style. For the `"aligned"` style I am not completely sure whether users prefer to see the milestones in source order (with crossing lines) or in chronological order.